### PR TITLE
Add Typgraphy presets

### DIFF
--- a/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
+++ b/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
@@ -1,8 +1,7 @@
 package com.theguardian.source.typography
 
+import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
@@ -11,8 +10,16 @@ import com.theguardian.source.R
 import com.theguardian.source.utils.fontFamilyResource
 
 /**
- * Source defined typography presets.
- * Each preset includes the font face, weight, size, and line height.
+ * App typography presets
+ * The Guardian has four bespoke typefaces, which were created for different purposes. When
+ * used effectively, they create contrast and alter the tone in which text is read.
+ *
+ * **Where do we use app typography presets?**
+ * Any content crafted and developed within the app's native environment, including the app
+ * fronts, My Guardian, custom modals, and supporter revenue messages.
+ *
+ * Note: Article pages and sign-in/registration pages are presented in a webview, hence
+ * utilising web typography presets.
  */
 object Typography {
     @Suppress("MagicNumber")
@@ -22,19 +29,17 @@ object Typography {
         const val Loose = 1.4f
     }
 
-    private object Weight {
-        val light = FontWeight.W300
-        val regular = FontWeight.W400
-        val medium = FontWeight.W500
-        val bold = FontWeight.W700
-    }
-
+    @Suppress("ObjectPropertyNaming")
     private object TextSize {
+        val _11 = 11.sp
         val _12 = 12.sp
         val _14 = 14.sp
         val _15 = 15.sp
+        val _16 = 16.sp
         val _17 = 17.sp
+        val _18 = 18.sp
         val _20 = 20.sp
+        val _22 = 22.sp
         val _24 = 24.sp
         val _28 = 28.sp
         val _34 = 34.sp
@@ -43,735 +48,1343 @@ object Typography {
         val _70 = 70.sp
     }
 
-    object Body {
-        val xSmall = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Loose * TextSize._14,
-            fontWeight = Weight.regular,
-        )
-        val small = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Loose * TextSize._15,
-            fontWeight = Weight.regular,
-        )
-        val medium = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Loose * TextSize._17,
-            fontWeight = Weight.regular,
-        )
-    }
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
 
-    object TextSans {
-        val xxSmall = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._12,
-            lineHeight = LineHeight.Regular * TextSize._12,
-            fontWeight = Weight.regular,
-        )
-        val xSmall = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = Weight.regular,
-        )
-        val small = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = Weight.regular,
-        )
-        val medium = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = Weight.regular,
-        )
-        val large = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Regular * TextSize._20,
-            fontWeight = Weight.regular,
-        )
-        val xLarge = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Regular * TextSize._24,
-            fontWeight = Weight.regular,
-        )
-        val xxLarge = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Regular * TextSize._28,
-            fontWeight = Weight.regular,
-        )
-        val xxxLarge = TextStyle(
-            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Regular * TextSize._34,
-            fontWeight = Weight.regular,
-        )
-    }
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold16 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold18 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold20 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold22 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold34 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineBold42 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight16 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight18 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight20 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight22 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight34 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineLight42 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium16 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium18 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium20 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium22 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium34 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMedium42 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic16 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic18 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic20 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic22 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic34 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineMediumItalic42 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineSemiBold14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineSemiBold15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineSemiBold16 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineSemiBold18 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineSemiBold24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+    val headlineSemiBold28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticle15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticle17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticleBold15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticleBold17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticleItalic15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticleItalic17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticleBoldItalic15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for article body text. */
+    val textArticleBoldItalic17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    val textEgyptian14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    val textEgyptian15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    val textEgyptian17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+    val textEgyptianBold14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+    val textEgyptianBold15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+    val textEgyptianBold17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+    val textEgyptianBoldItalic14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+    val textEgyptianBoldItalic15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+    val textEgyptianBoldItalic17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    val textEgyptianItalic14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    val textEgyptianItalic15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+    val textEgyptianItalic17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
 
     /**
-     * Use for headlines, headings and any short form text like pull quotes, bylines and titles.
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
      */
-    object Headline {
-        val xxxSmall = TextStyle(
-            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Tight * TextSize._17,
-            fontWeight = Weight.medium,
-        )
-        val xxSmall = TextStyle(
-            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Tight * TextSize._20,
-            fontWeight = Weight.medium,
-        )
-        val xSmall = TextStyle(
-            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Tight * TextSize._24,
-            fontWeight = Weight.medium,
-        )
-        val small = TextStyle(
-            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Tight * TextSize._28,
-            fontWeight = Weight.medium,
-        )
-        val medium = TextStyle(
-            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Tight * TextSize._34,
-            fontWeight = Weight.medium,
-        )
-        val large = TextStyle(
-            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = Weight.medium,
-        )
-        val xLarge = TextStyle(
-            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = Weight.medium,
-        )
-    }
+    val textSans11 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._11,
+        lineHeight = LineHeight.Regular * TextSize._11,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
 
-    object Titlepiece {
-        val small = TextStyle(
-            fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = Weight.bold,
-        )
-        val medium = TextStyle(
-            fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = Weight.bold,
-        )
-        val large = TextStyle(
-            fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
-            fontSize = TextSize._70,
-            lineHeight = LineHeight.Tight * TextSize._70,
-            fontWeight = Weight.bold,
-        )
-    }
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans12 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._12,
+        lineHeight = LineHeight.Regular * TextSize._12,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
 
-    val presets = mapOf(
-        "headlineBold14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Tight * TextSize._14,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Tight * TextSize._17,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Tight * TextSize._20,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Tight * TextSize._24,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Tight * TextSize._28,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Tight * TextSize._34,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold42" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold50" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineBold70" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._70,
-            lineHeight = LineHeight.Tight * TextSize._70,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Tight * TextSize._14,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Tight * TextSize._17,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Tight * TextSize._20,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Tight * TextSize._24,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Tight * TextSize._28,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Tight * TextSize._34,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight42" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight50" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLight70" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._70,
-            lineHeight = LineHeight.Tight * TextSize._70,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineLightItalic14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Tight * TextSize._14,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Tight * TextSize._17,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Tight * TextSize._20,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Tight * TextSize._24,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Tight * TextSize._28,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Tight * TextSize._34,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic42" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic50" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineLightItalic70" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._70,
-            lineHeight = LineHeight.Tight * TextSize._70,
-            fontWeight = FontWeight.W300,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMedium14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Tight * TextSize._14,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Tight * TextSize._17,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Tight * TextSize._20,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Tight * TextSize._24,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Tight * TextSize._28,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Tight * TextSize._34,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium42" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium50" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMedium70" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._70,
-            lineHeight = LineHeight.Tight * TextSize._70,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Normal,
-        ),
-        "headlineMediumItalic14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Tight * TextSize._14,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Tight * TextSize._17,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Tight * TextSize._20,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Tight * TextSize._24,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Tight * TextSize._28,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Tight * TextSize._34,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic42" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic50" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = FontWeight.W500,
-            fontStyle = FontStyle.Italic,
-        ),
-        "headlineMediumItalic70" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-            fontSize = TextSize._70,
-            lineHeight = LineHeight.Tight * TextSize._70,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textEgyptian14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textEgyptian15" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textEgyptian17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textEgyptianBold14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textEgyptianBold15" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textEgyptianBold17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textEgyptianBoldItalic14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textEgyptianBoldItalic15" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textEgyptianBoldItalic17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textEgyptianItalic14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textEgyptianItalic15" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textEgyptianItalic17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSans12" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._12,
-            lineHeight = LineHeight.Regular * TextSize._12,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSans14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSans15" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSans17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSans20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Regular * TextSize._20,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSans24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Regular * TextSize._24,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSans28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Regular * TextSize._28,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSans34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Regular * TextSize._34,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold12" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._12,
-            lineHeight = LineHeight.Regular * TextSize._12,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold15" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Regular * TextSize._20,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Regular * TextSize._24,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Regular * TextSize._28,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansBold34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Regular * TextSize._34,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "textSansItalic12" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._12,
-            lineHeight = LineHeight.Regular * TextSize._12,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSansItalic14" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._14,
-            lineHeight = LineHeight.Regular * TextSize._14,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSansItalic15" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._15,
-            lineHeight = LineHeight.Regular * TextSize._15,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSansItalic17" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._17,
-            lineHeight = LineHeight.Regular * TextSize._17,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSansItalic20" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._20,
-            lineHeight = LineHeight.Regular * TextSize._20,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSansItalic24" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._24,
-            lineHeight = LineHeight.Regular * TextSize._24,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSansItalic28" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._28,
-            lineHeight = LineHeight.Regular * TextSize._28,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "textSansItalic34" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
-            fontSize = TextSize._34,
-            lineHeight = LineHeight.Regular * TextSize._34,
-            fontWeight = FontWeight.W400,
-            fontStyle = FontStyle.Italic,
-        ),
-        "titlepiece42" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
-            fontSize = TextSize._42,
-            lineHeight = LineHeight.Tight * TextSize._42,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "titlepiece50" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
-            fontSize = TextSize._50,
-            lineHeight = LineHeight.Tight * TextSize._50,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
-        "titlepiece70" to TextStyle(
-            fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
-            fontSize = TextSize._70,
-            lineHeight = LineHeight.Tight * TextSize._70,
-            fontWeight = FontWeight.W700,
-            fontStyle = FontStyle.Normal,
-        ),
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans20 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Regular * TextSize._20,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Regular * TextSize._24,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Regular * TextSize._28,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSans34 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Regular * TextSize._34,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold11 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._11,
+        lineHeight = LineHeight.Regular * TextSize._11,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold12 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._12,
+        lineHeight = LineHeight.Regular * TextSize._12,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold20 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Regular * TextSize._20,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Regular * TextSize._24,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Regular * TextSize._28,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansBold34 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Regular * TextSize._34,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    // TODO: 12/04/2024 App doesn't have an italic text sans font so using regular
+    val textSansItalic11 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._11,
+        lineHeight = LineHeight.Regular * TextSize._11,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic12 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._12,
+        lineHeight = LineHeight.Regular * TextSize._12,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic14 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic15 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic17 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic20 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Regular * TextSize._20,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic24 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Regular * TextSize._24,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic28 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Regular * TextSize._28,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for interactive page elements like buttons and text input fields and for meta
+     * information like datelines, image captions and data visualisations. Use for interactive
+     * page elements like buttons and text input fields and for meta information like datelines,
+     * image captions and data visualisations.Use for interactive page elements like buttons and
+     * text input fields and for meta information like datelines, image captions and data
+     * visualisations.Use for interactive page elements like buttons and text input fields and
+     * for meta information like datelines, image captions and data visualisations.
+     *
+     *
+     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+     * from editorial content.
+     */
+    val textSansItalic34 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Regular * TextSize._34,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
+     * and at large sizes only.
+     */
+    val titlepiece42 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
+     * and at large sizes only.
+     */
+    val titlepiece50 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
+        fontSize = TextSize._50,
+        lineHeight = LineHeight.Tight * TextSize._50,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    /**
+     * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
+     * and at large sizes only.
+     */
+    val titlepiece70 = TextStyle(
+        fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
+        fontSize = TextSize._70,
+        lineHeight = LineHeight.Tight * TextSize._70,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 }

--- a/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
+++ b/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
@@ -3,20 +3,23 @@ package com.theguardian.source.typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.times
 import com.theguardian.source.R
+import com.theguardian.source.utils.fontFamilyResource
 
 /**
  * Source defined typography presets.
  * Each preset includes the font face, weight, size, and line height.
  */
 object Typography {
+    @Suppress("MagicNumber")
     private object LineHeight {
-        val tight = 1.15f
-        val regular = 1.3f
-        val loose = 1.4f
+        const val Tight = 1.15f
+        const val Regular = 1.3f
+        const val Loose = 1.4f
     }
 
     private object Weight {
@@ -44,19 +47,19 @@ object Typography {
         val xSmall = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
             fontSize = TextSize._14,
-            lineHeight = LineHeight.loose * TextSize._14,
+            lineHeight = LineHeight.Loose * TextSize._14,
             fontWeight = Weight.regular,
         )
         val small = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
             fontSize = TextSize._15,
-            lineHeight = LineHeight.loose * TextSize._15,
+            lineHeight = LineHeight.Loose * TextSize._15,
             fontWeight = Weight.regular,
         )
         val medium = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
             fontSize = TextSize._17,
-            lineHeight = LineHeight.loose * TextSize._17,
+            lineHeight = LineHeight.Loose * TextSize._17,
             fontWeight = Weight.regular,
         )
     }
@@ -65,94 +68,97 @@ object Typography {
         val xxSmall = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._12,
-            lineHeight = LineHeight.regular * TextSize._12,
+            lineHeight = LineHeight.Regular * TextSize._12,
             fontWeight = Weight.regular,
         )
         val xSmall = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._14,
-            lineHeight = LineHeight.regular * TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
             fontWeight = Weight.regular,
         )
         val small = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._15,
-            lineHeight = LineHeight.regular * TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
             fontWeight = Weight.regular,
         )
         val medium = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._17,
-            lineHeight = LineHeight.regular * TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
             fontWeight = Weight.regular,
         )
         val large = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._20,
-            lineHeight = LineHeight.regular * TextSize._20,
+            lineHeight = LineHeight.Regular * TextSize._20,
             fontWeight = Weight.regular,
         )
         val xLarge = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._24,
-            lineHeight = LineHeight.regular * TextSize._24,
+            lineHeight = LineHeight.Regular * TextSize._24,
             fontWeight = Weight.regular,
         )
         val xxLarge = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._28,
-            lineHeight = LineHeight.regular * TextSize._28,
+            lineHeight = LineHeight.Regular * TextSize._28,
             fontWeight = Weight.regular,
         )
         val xxxLarge = TextStyle(
             fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
             fontSize = TextSize._34,
-            lineHeight = LineHeight.regular * TextSize._34,
+            lineHeight = LineHeight.Regular * TextSize._34,
             fontWeight = Weight.regular,
         )
     }
 
+    /**
+     * Use for headlines, headings and any short form text like pull quotes, bylines and titles.
+     */
     object Headline {
         val xxxSmall = TextStyle(
             fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
             fontSize = TextSize._17,
-            lineHeight = LineHeight.tight * TextSize._17,
+            lineHeight = LineHeight.Tight * TextSize._17,
             fontWeight = Weight.medium,
         )
         val xxSmall = TextStyle(
             fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
             fontSize = TextSize._20,
-            lineHeight = LineHeight.tight * TextSize._20,
+            lineHeight = LineHeight.Tight * TextSize._20,
             fontWeight = Weight.medium,
         )
         val xSmall = TextStyle(
             fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
             fontSize = TextSize._24,
-            lineHeight = LineHeight.tight * TextSize._24,
+            lineHeight = LineHeight.Tight * TextSize._24,
             fontWeight = Weight.medium,
         )
         val small = TextStyle(
             fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
             fontSize = TextSize._28,
-            lineHeight = LineHeight.tight * TextSize._28,
+            lineHeight = LineHeight.Tight * TextSize._28,
             fontWeight = Weight.medium,
         )
         val medium = TextStyle(
             fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
             fontSize = TextSize._34,
-            lineHeight = LineHeight.tight * TextSize._34,
+            lineHeight = LineHeight.Tight * TextSize._34,
             fontWeight = Weight.medium,
         )
         val large = TextStyle(
             fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
             fontSize = TextSize._42,
-            lineHeight = LineHeight.tight * TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
             fontWeight = Weight.medium,
         )
         val xLarge = TextStyle(
             fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
             fontSize = TextSize._50,
-            lineHeight = LineHeight.tight * TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
             fontWeight = Weight.medium,
         )
     }
@@ -161,20 +167,611 @@ object Typography {
         val small = TextStyle(
             fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
             fontSize = TextSize._42,
-            lineHeight = LineHeight.tight * TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
             fontWeight = Weight.bold,
         )
         val medium = TextStyle(
             fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
             fontSize = TextSize._50,
-            lineHeight = LineHeight.tight * TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
             fontWeight = Weight.bold,
         )
         val large = TextStyle(
             fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
             fontSize = TextSize._70,
-            lineHeight = LineHeight.tight * TextSize._70,
+            lineHeight = LineHeight.Tight * TextSize._70,
             fontWeight = Weight.bold,
         )
     }
+
+    val presets = mapOf(
+        "headlineBold14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Tight * TextSize._14,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Tight * TextSize._17,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Tight * TextSize._20,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Tight * TextSize._24,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Tight * TextSize._28,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Tight * TextSize._34,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold42" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold50" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineBold70" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._70,
+            lineHeight = LineHeight.Tight * TextSize._70,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Tight * TextSize._14,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Tight * TextSize._17,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Tight * TextSize._20,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Tight * TextSize._24,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Tight * TextSize._28,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Tight * TextSize._34,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight42" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight50" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLight70" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._70,
+            lineHeight = LineHeight.Tight * TextSize._70,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineLightItalic14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Tight * TextSize._14,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Tight * TextSize._17,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Tight * TextSize._20,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Tight * TextSize._24,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Tight * TextSize._28,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Tight * TextSize._34,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic42" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic50" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineLightItalic70" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._70,
+            lineHeight = LineHeight.Tight * TextSize._70,
+            fontWeight = FontWeight.W300,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMedium14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Tight * TextSize._14,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Tight * TextSize._17,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Tight * TextSize._20,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Tight * TextSize._24,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Tight * TextSize._28,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Tight * TextSize._34,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium42" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium50" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMedium70" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._70,
+            lineHeight = LineHeight.Tight * TextSize._70,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Normal,
+        ),
+        "headlineMediumItalic14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Tight * TextSize._14,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Tight * TextSize._17,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Tight * TextSize._20,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Tight * TextSize._24,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Tight * TextSize._28,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Tight * TextSize._34,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic42" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic50" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
+            fontWeight = FontWeight.W500,
+            fontStyle = FontStyle.Italic,
+        ),
+        "headlineMediumItalic70" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+            fontSize = TextSize._70,
+            lineHeight = LineHeight.Tight * TextSize._70,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textEgyptian14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textEgyptian15" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textEgyptian17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textEgyptianBold14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textEgyptianBold15" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textEgyptianBold17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textEgyptianBoldItalic14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textEgyptianBoldItalic15" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textEgyptianBoldItalic17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textEgyptianItalic14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textEgyptianItalic15" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textEgyptianItalic17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSans12" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._12,
+            lineHeight = LineHeight.Regular * TextSize._12,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSans14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSans15" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSans17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSans20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Regular * TextSize._20,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSans24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Regular * TextSize._24,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSans28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Regular * TextSize._28,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSans34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Regular * TextSize._34,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold12" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._12,
+            lineHeight = LineHeight.Regular * TextSize._12,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold15" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Regular * TextSize._20,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Regular * TextSize._24,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Regular * TextSize._28,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansBold34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Regular * TextSize._34,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "textSansItalic12" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._12,
+            lineHeight = LineHeight.Regular * TextSize._12,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSansItalic14" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.Regular * TextSize._14,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSansItalic15" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.Regular * TextSize._15,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSansItalic17" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.Regular * TextSize._17,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSansItalic20" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.Regular * TextSize._20,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSansItalic24" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.Regular * TextSize._24,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSansItalic28" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.Regular * TextSize._28,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "textSansItalic34" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.Regular * TextSize._34,
+            fontWeight = FontWeight.W400,
+            fontStyle = FontStyle.Italic,
+        ),
+        "titlepiece42" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.Tight * TextSize._42,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "titlepiece50" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.Tight * TextSize._50,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+        "titlepiece70" to TextStyle(
+            fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
+            fontSize = TextSize._70,
+            lineHeight = LineHeight.Tight * TextSize._70,
+            fontWeight = FontWeight.W700,
+            fontStyle = FontStyle.Normal,
+        ),
+    )
 }

--- a/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
+++ b/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
@@ -1,0 +1,180 @@
+package com.theguardian.source.typography
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.times
+import com.theguardian.source.R
+
+/**
+ * Source defined typography presets.
+ * Each preset includes the font face, weight, size, and line height.
+ */
+object Typography {
+    private object LineHeight {
+        val tight = 1.15f
+        val regular = 1.3f
+        val loose = 1.4f
+    }
+
+    private object Weight {
+        val light = FontWeight.W300
+        val regular = FontWeight.W400
+        val medium = FontWeight.W500
+        val bold = FontWeight.W700
+    }
+
+    private object TextSize {
+        val _12 = 12.sp
+        val _14 = 14.sp
+        val _15 = 15.sp
+        val _17 = 17.sp
+        val _20 = 20.sp
+        val _24 = 24.sp
+        val _28 = 28.sp
+        val _34 = 34.sp
+        val _42 = 42.sp
+        val _50 = 50.sp
+        val _70 = 70.sp
+    }
+
+    object Body {
+        val xSmall = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.loose * TextSize._14,
+            fontWeight = Weight.regular,
+        )
+        val small = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.loose * TextSize._15,
+            fontWeight = Weight.regular,
+        )
+        val medium = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardiantextegyptian_regular)),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.loose * TextSize._17,
+            fontWeight = Weight.regular,
+        )
+    }
+
+    object TextSans {
+        val xxSmall = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._12,
+            lineHeight = LineHeight.regular * TextSize._12,
+            fontWeight = Weight.regular,
+        )
+        val xSmall = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._14,
+            lineHeight = LineHeight.regular * TextSize._14,
+            fontWeight = Weight.regular,
+        )
+        val small = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._15,
+            lineHeight = LineHeight.regular * TextSize._15,
+            fontWeight = Weight.regular,
+        )
+        val medium = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.regular * TextSize._17,
+            fontWeight = Weight.regular,
+        )
+        val large = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.regular * TextSize._20,
+            fontWeight = Weight.regular,
+        )
+        val xLarge = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.regular * TextSize._24,
+            fontWeight = Weight.regular,
+        )
+        val xxLarge = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.regular * TextSize._28,
+            fontWeight = Weight.regular,
+        )
+        val xxxLarge = TextStyle(
+            fontFamily = FontFamily(Font(R.font.guardian_texsan_two_regular)),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.regular * TextSize._34,
+            fontWeight = Weight.regular,
+        )
+    }
+
+    object Headline {
+        val xxxSmall = TextStyle(
+            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
+            fontSize = TextSize._17,
+            lineHeight = LineHeight.tight * TextSize._17,
+            fontWeight = Weight.medium,
+        )
+        val xxSmall = TextStyle(
+            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
+            fontSize = TextSize._20,
+            lineHeight = LineHeight.tight * TextSize._20,
+            fontWeight = Weight.medium,
+        )
+        val xSmall = TextStyle(
+            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
+            fontSize = TextSize._24,
+            lineHeight = LineHeight.tight * TextSize._24,
+            fontWeight = Weight.medium,
+        )
+        val small = TextStyle(
+            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
+            fontSize = TextSize._28,
+            lineHeight = LineHeight.tight * TextSize._28,
+            fontWeight = Weight.medium,
+        )
+        val medium = TextStyle(
+            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
+            fontSize = TextSize._34,
+            lineHeight = LineHeight.tight * TextSize._34,
+            fontWeight = Weight.medium,
+        )
+        val large = TextStyle(
+            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.tight * TextSize._42,
+            fontWeight = Weight.medium,
+        )
+        val xLarge = TextStyle(
+            fontFamily = FontFamily(Font(R.font.ghguardianheadline_medium)),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.tight * TextSize._50,
+            fontWeight = Weight.medium,
+        )
+    }
+
+    object Titlepiece {
+        val small = TextStyle(
+            fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
+            fontSize = TextSize._42,
+            lineHeight = LineHeight.tight * TextSize._42,
+            fontWeight = Weight.bold,
+        )
+        val medium = TextStyle(
+            fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
+            fontSize = TextSize._50,
+            lineHeight = LineHeight.tight * TextSize._50,
+            fontWeight = Weight.bold,
+        )
+        val large = TextStyle(
+            fontFamily = FontFamily(Font(R.font.gtguardiantitlepiece_bold)),
+            fontSize = TextSize._70,
+            lineHeight = LineHeight.tight * TextSize._70,
+            fontWeight = Weight.bold,
+        )
+    }
+}

--- a/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
+++ b/source/src/main/kotlin/com/theguardian/source/typography/Typography.kt
@@ -21,33 +21,8 @@ import com.theguardian.source.utils.fontFamilyResource
  * Note: Article pages and sign-in/registration pages are presented in a webview, hence
  * utilising web typography presets.
  */
+@Suppress("LargeClass")
 object Typography {
-    @Suppress("MagicNumber")
-    private object LineHeight {
-        const val Tight = 1.15f
-        const val Regular = 1.3f
-        const val Loose = 1.4f
-    }
-
-    @Suppress("ObjectPropertyNaming")
-    private object TextSize {
-        val _11 = 11.sp
-        val _12 = 12.sp
-        val _14 = 14.sp
-        val _15 = 15.sp
-        val _16 = 16.sp
-        val _17 = 17.sp
-        val _18 = 18.sp
-        val _20 = 20.sp
-        val _22 = 22.sp
-        val _24 = 24.sp
-        val _28 = 28.sp
-        val _34 = 34.sp
-        val _42 = 42.sp
-        val _50 = 50.sp
-        val _70 = 70.sp
-    }
-
     /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
     val headlineBold14 = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
@@ -1387,4 +1362,30 @@ object Typography {
         fontStyle = FontStyle.Normal,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
+}
+
+@Suppress("MagicNumber")
+private object LineHeight {
+    const val Tight = 1.15f
+    const val Regular = 1.3f
+    const val Loose = 1.4f
+}
+
+@Suppress("ObjectPropertyNaming")
+private object TextSize {
+    val _11 = 11.sp
+    val _12 = 12.sp
+    val _14 = 14.sp
+    val _15 = 15.sp
+    val _16 = 16.sp
+    val _17 = 17.sp
+    val _18 = 18.sp
+    val _20 = 20.sp
+    val _22 = 22.sp
+    val _24 = 24.sp
+    val _28 = 28.sp
+    val _34 = 34.sp
+    val _42 = 42.sp
+    val _50 = 50.sp
+    val _70 = 70.sp
 }

--- a/source/src/main/kotlin/com/theguardian/source/typography/TypographyPreview.kt
+++ b/source/src/main/kotlin/com/theguardian/source/typography/TypographyPreview.kt
@@ -150,7 +150,6 @@ private fun Preview() {
                 style = Typography.headlineLight42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
-
         }
 
         FlowRow {

--- a/source/src/main/kotlin/com/theguardian/source/typography/TypographyPreview.kt
+++ b/source/src/main/kotlin/com/theguardian/source/typography/TypographyPreview.kt
@@ -1,0 +1,642 @@
+package com.theguardian.source.typography
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalLayoutApi::class)
+@Preview(device = Devices.PIXEL_C, showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun Preview() {
+    Column {
+        FlowRow {
+            Text(
+                text = "headlineBold14",
+                style = Typography.headlineBold14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold15",
+                style = Typography.headlineBold15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold16",
+                style = Typography.headlineBold16,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold17",
+                style = Typography.headlineBold17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold18",
+                style = Typography.headlineBold18,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold20",
+                style = Typography.headlineBold20,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold22",
+                style = Typography.headlineBold22,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold24",
+                style = Typography.headlineBold24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold28",
+                style = Typography.headlineBold28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold34",
+                style = Typography.headlineBold34,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineBold42",
+                style = Typography.headlineBold42,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "headlineLight14",
+                style = Typography.headlineLight14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight15",
+                style = Typography.headlineLight15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight16",
+                style = Typography.headlineLight16,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight17",
+                style = Typography.headlineLight17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight18",
+                style = Typography.headlineLight18,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight20",
+                style = Typography.headlineLight20,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight22",
+                style = Typography.headlineLight22,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight24",
+                style = Typography.headlineLight24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight28",
+                style = Typography.headlineLight28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight34",
+                style = Typography.headlineLight34,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineLight42",
+                style = Typography.headlineLight42,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+        }
+
+        FlowRow {
+            Text(
+                text = "headlineMedium14",
+                style = Typography.headlineMedium14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium15",
+                style = Typography.headlineMedium15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium16",
+                style = Typography.headlineMedium16,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium17",
+                style = Typography.headlineMedium17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium18",
+                style = Typography.headlineMedium18,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium20",
+                style = Typography.headlineMedium20,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium22",
+                style = Typography.headlineMedium22,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium24",
+                style = Typography.headlineMedium24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium28",
+                style = Typography.headlineMedium28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium34",
+                style = Typography.headlineMedium34,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMedium42",
+                style = Typography.headlineMedium42,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "headlineMediumItalic14",
+                style = Typography.headlineMediumItalic14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic15",
+                style = Typography.headlineMediumItalic15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic16",
+                style = Typography.headlineMediumItalic16,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic17",
+                style = Typography.headlineMediumItalic17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic18",
+                style = Typography.headlineMediumItalic18,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic20",
+                style = Typography.headlineMediumItalic20,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic22",
+                style = Typography.headlineMediumItalic22,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic24",
+                style = Typography.headlineMediumItalic24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic28",
+                style = Typography.headlineMediumItalic28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic34",
+                style = Typography.headlineMediumItalic34,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineMediumItalic42",
+                style = Typography.headlineMediumItalic42,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "headlineSemiBold14",
+                style = Typography.headlineSemiBold14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineSemiBold15",
+                style = Typography.headlineSemiBold15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineSemiBold16",
+                style = Typography.headlineSemiBold16,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineSemiBold18",
+                style = Typography.headlineSemiBold18,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineSemiBold24",
+                style = Typography.headlineSemiBold24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "headlineSemiBold28",
+                style = Typography.headlineSemiBold28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "textArticle15",
+                style = Typography.textArticle15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textArticle17",
+                style = Typography.textArticle17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textArticleBold15",
+                style = Typography.textArticleBold15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textArticleBold17",
+                style = Typography.textArticleBold17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textArticleItalic15",
+                style = Typography.textArticleItalic15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textArticleItalic17",
+                style = Typography.textArticleItalic17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textArticleBoldItalic15",
+                style = Typography.textArticleBoldItalic15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textArticleBoldItalic17",
+                style = Typography.textArticleBoldItalic17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "textEgyptian14",
+                style = Typography.textEgyptian14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptian15",
+                style = Typography.textEgyptian15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptian17",
+                style = Typography.textEgyptian17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianBold14",
+                style = Typography.textEgyptianBold14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianBold15",
+                style = Typography.textEgyptianBold15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianBold17",
+                style = Typography.textEgyptianBold17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianBoldItalic14",
+                style = Typography.textEgyptianBoldItalic14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianBoldItalic15",
+                style = Typography.textEgyptianBoldItalic15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianBoldItalic17",
+                style = Typography.textEgyptianBoldItalic17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianItalic14",
+                style = Typography.textEgyptianItalic14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianItalic15",
+                style = Typography.textEgyptianItalic15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textEgyptianItalic17",
+                style = Typography.textEgyptianItalic17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "textSans11",
+                style = Typography.textSans11,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans12",
+                style = Typography.textSans12,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans14",
+                style = Typography.textSans14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans15",
+                style = Typography.textSans15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans17",
+                style = Typography.textSans17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans20",
+                style = Typography.textSans20,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans24",
+                style = Typography.textSans24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans28",
+                style = Typography.textSans28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSans34",
+                style = Typography.textSans34,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "textSansBold11",
+                style = Typography.textSansBold11,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold12",
+                style = Typography.textSansBold12,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold14",
+                style = Typography.textSansBold14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold15",
+                style = Typography.textSansBold15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold17",
+                style = Typography.textSansBold17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold20",
+                style = Typography.textSansBold20,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold24",
+                style = Typography.textSansBold24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold28",
+                style = Typography.textSansBold28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansBold34",
+                style = Typography.textSansBold34,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "textSansItalic11",
+                style = Typography.textSansItalic11,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic12",
+                style = Typography.textSansItalic12,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic14",
+                style = Typography.textSansItalic14,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic15",
+                style = Typography.textSansItalic15,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic17",
+                style = Typography.textSansItalic17,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic20",
+                style = Typography.textSansItalic20,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic24",
+                style = Typography.textSansItalic24,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic28",
+                style = Typography.textSansItalic28,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "textSansItalic34",
+                style = Typography.textSansItalic34,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+
+        FlowRow {
+            Text(
+                text = "titlepiece42",
+                style = Typography.titlepiece42,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "titlepiece50",
+                style = Typography.titlepiece50,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+
+            Text(
+                text = "titlepiece70",
+                style = Typography.titlepiece70,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+    }
+}

--- a/source/src/main/kotlin/com/theguardian/source/utils/fontFamilyResource.kt
+++ b/source/src/main/kotlin/com/theguardian/source/utils/fontFamilyResource.kt
@@ -8,4 +8,4 @@ import androidx.compose.ui.text.font.FontFamily
 /**
  * Load the font resource into a FontFamily object.
  */
-fun fontFamilyResource(@FontRes fontResId: Int) = FontFamily(Font(fontResId))
+internal fun fontFamilyResource(@FontRes fontResId: Int) = FontFamily(Font(fontResId))

--- a/source/src/main/kotlin/com/theguardian/source/utils/fontFamilyResource.kt
+++ b/source/src/main/kotlin/com/theguardian/source/utils/fontFamilyResource.kt
@@ -1,0 +1,7 @@
+package com.theguardian.source.utils
+
+import androidx.annotation.FontRes
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+
+fun fontFamilyResource(@FontRes fontResId: Int) = FontFamily(Font(fontResId))

--- a/source/src/main/kotlin/com/theguardian/source/utils/fontFamilyResource.kt
+++ b/source/src/main/kotlin/com/theguardian/source/utils/fontFamilyResource.kt
@@ -1,7 +1,11 @@
+// ktlint-disable filename
 package com.theguardian.source.utils
 
 import androidx.annotation.FontRes
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 
+/**
+ * Load the font resource into a FontFamily object.
+ */
 fun fontFamilyResource(@FontRes fontResId: Int) = FontFamily(Font(fontResId))


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Hand crafted app typography presets tokens to match [those in source](https://theguardian.design/2a1e5182b/p/01555f-typography-presets/b/814fba).

Note: Some fonts mentioned in the presets aren't available in the app. Nearest approximation with the correct weight/style have been used. The missing fonts are:

1. Egyptian Bold
2. Egyptian Bold Italic
3. Text Sans Italic

## How to test

Haven't done test integration on CI. At the moment, the best way to test is to verify individual token in `Typography.kt` with the description at the link above.

This isn't practical, so _just accept this_ for now.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![font-preview](https://github.com/guardian/source-android/assets/79363218/2c1e5bbf-f930-45f6-8ed3-c3d0580a09fd)

